### PR TITLE
Refactor for compatibility with sslyze version >=5.0.6,<= 5.1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         "requests>=2.18.4",
         # This is necessary to support the python_requires kwarg
         "setuptools >= 24.2.0",
-        "sslyze>=3.0.0,<5.0.0",
+        "sslyze>=5.0.6,<=5.1.3",
         "wget>=3.2",
     ],
     extras_require={

--- a/src/pshtt/pshtt.py
+++ b/src/pshtt/pshtt.py
@@ -27,7 +27,7 @@ from sslyze import (  # type: ignore
 )
 from sslyze.errors import ConnectionToServerFailed  # type: ignore
 from sslyze.plugins.certificate_info.implementation import (  # type: ignore
-    CertificateInfoExtraArguments,
+    CertificateInfoExtraArgument,
 )
 from sslyze.plugins.scan_commands import ScanCommand  # type: ignore
 import urllib3
@@ -696,7 +696,7 @@ def https_check(endpoint):
         command = ScanCommand.CERTIFICATE_INFO
         if CA_FILE is not None:
             command_extra_args = {
-                command: CertificateInfoExtraArguments(custom_ca_file=Path(CA_FILE))
+                command: CertificateInfoExtraArgument(custom_ca_file=Path(CA_FILE))
             }
             scan_request = ServerScanRequest(
                 server_info=server_info,
@@ -874,7 +874,7 @@ def https_check(endpoint):
                         scanner = Scanner()
                         command = ScanCommand.CERTIFICATE_INFO
                         command_extra_args = {
-                            command: CertificateInfoExtraArguments(
+                            command: CertificateInfoExtraArgument(
                                 custom_ca_file=Path(PT_INT_CA_FILE)
                             )
                         }


### PR DESCRIPTION
### Summary
Bumped sslyze version; Three classes needed to be refactored. These three were imported in src/pshtt/pshtt.py but no longer exist in sslyze as of 5.0.0. 

### Motivation
sslyze>=5.0.6 is required for pshtt to be integrated with Crossfeed.

### Detailed Changes
Refactor
- ServerConnectivityTester
  - From: ServerConnectivityTester.perform
  - To: ServerTlsProbingResult.check_connectivity_to_server
- ServerNetworkLocationViaDirectConnection
  - From: ServerNetworkLocationViaDirectConnection.with_ip_address_lookup
  - To: ServerNetworkLocation._do_dns_lookup
- CertificateInfoExtraArguments
  - From: CertificateInfoExtraArguments
  - To: CertificateInfoExtraArgument

### Testing
Ran 26 tests from Tests directory:
21 passed, 5 skipped

Successfully built Crossfeed locally and ran pshtt scans without requirements conflict.



